### PR TITLE
Use CLI 2.0

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -18,7 +18,7 @@
     "eslint": "^4.5.0",
     "eslint-config-synacor": "^1.1.0",
     "if-env": "^1.0.0",
-    "preact-cli": "^1.4.1"
+    "preact-cli": "^2.0.0"
   },
   "dependencies": {
     "preact": "^8.2.1",


### PR DESCRIPTION
The CLI is cloning this repo, which means that all new installs are still using `preact-cli@1.4.1`.

Merging this means that all new installs will have non-working HMR (https://github.com/developit/preact-cli/issues/400), but at least it will be up-to-date.