### PR TITLE
chore(dependency): remove preact-compat

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -22,7 +22,6 @@
   },
   "dependencies": {
     "preact": "^8.2.1",
-    "preact-compat": "^3.17.0",
     "preact-router": "^2.5.5"
   }
 }


### PR DESCRIPTION
Hey everyone 👋 

I don't know if there's a specific reason to keep this dependency inside the default template, but since it's not used by default and it's recommended to "avoid" using `preact-compat` if you are starting from scratch.

This is why I'm proposing to remove it from dependencies.
If this is accepted I'll create PR for the same in other template.