### PR TITLE
Fix `.babelrc` file

### DIFF
--- a/template/.babelrc
+++ b/template/.babelrc
@@ -1,5 +1,9 @@
 {
-    "presets": [ 
+  "env": {
+    "test": {
+      "presets": [
         ["preact-cli/babel", { "modules": "commonjs" }]
-    ]
+      ]
+    }
+  }
 }


### PR DESCRIPTION
It was overriding the `presets` with `modules: 'commonjs'` across _all_ environments. It should only be doing this when testing.