### PR TITLE
Switch from if-env to per-env

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -4,7 +4,9 @@
   "version": "0.0.0",
   "license": "MIT",
   "scripts": {
-    "start": "if-env NODE_ENV=production && npm run -s serve || npm run -s dev",
+    "start": "per-env",
+    "start:production": "npm run -s serve",
+    "start:development": "npm run -s dev",
     "build": "preact build",
     "serve": "preact build && preact serve",
     "dev": "preact watch",
@@ -21,7 +23,7 @@
     "eslint": "^4.9.0",
     "eslint-config-synacor": "^2.0.2",
     "identity-obj-proxy": "^3.0.0",
-    "if-env": "^1.0.0",
+    "per-env": "^1.0.2",
     "jest": "^21.2.1",
     "preact-cli": "^2.1.0",
     "preact-render-spy": "^1.2.1"


### PR DESCRIPTION
`if-env` is deprecated, and also affected by a backdoor discovered yesterday.