### PR TITLE
Fixed typo in config for jest

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -49,7 +49,7 @@
       "node_modules"
     ],
     "moduleNameMapper": {
-      "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/tests/__mocks__/fileMock.js",
+      "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/tests/__mocks__/fileMocks.js",
       "\\.(css|less|scss)$": "identity-obj-proxy",
       "^./style$": "identity-obj-proxy",
       "^preact$": "<rootDir>/node_modules/preact/dist/preact.min.js",


### PR DESCRIPTION
The test environment is set up to Mock static assets by mapping their imports to `fileMocks.js`. 
This is defined in jest's section of package.json using `moduleNameMapper`. 

Currently, this does not work due to a typo, the file is actually called `fileMocks.js` but in package.json it is referred to as `fileMock.js`

### To test :
1. #### Create a new tests app with preact-cli
    `preact create default test`
2. #### Add a test png to `src/assets/test.png`
3. #### Add it to the header component (this has a test setup by default)
    Add `import image from '../../assets/test.png'` and  `<img src={image} />` to 
    `src/components/header/index.js`
4. #### run `npm run test` which will result in this error
    ```
    Configuration error:
     
     Could not locate module ../../assets/img/icons/spinner.svg mapped as:
     /storage/Repos/www.zakwest.tech/tests/__mocks__/fileMock.js.
    ```
5. #### Apply this diff, edit `package.json` and change `fileMock.j` to `fileMocks.j`
   i.e.
   `"\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/tests/__mocks__/fileMock.js",`
   to
   `"\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/tests/__mocks__/fileMocks.js",`
6. #### Rerun tests `npm run test` which will now pass
    ```
     PASS  tests/header.test.js
     Initial Test of the Header
        ✓ Header renders 3 nav items (9ms)
    ```