### PR TITLE
Update default for Preact X

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -8,7 +8,7 @@
     "start:production": "npm run -s serve",
     "start:development": "npm run -s dev",
     "build": "preact build",
-    "serve": "preact build && preact serve",
+    "serve": "preact build && serve build --single",
     "dev": "preact watch",
     "lint": "eslint src",
     "test": "jest"
@@ -20,27 +20,32 @@
     "build/*"
   ],
   "devDependencies": {
-    "eslint": "^4.9.0",
-    "eslint-config-synacor": "^2.0.2",
+    "enzyme": "^3.10.0",
+    "enzyme-adapter-preact-pure": "^2.0.0",
+    "eslint": "^6.0.1",
+    "eslint-config-synacor": "^3.0.4",
     "identity-obj-proxy": "^3.0.0",
+    "jest": "^24.8.0",
     "per-env": "^1.0.2",
-    "jest": "^21.2.1",
-    "preact-cli": "^2.1.0",
-    "preact-render-spy": "^1.2.1"
+    "preact-cli": "^3.0.0-rc.3",
+    "serve": "^11.1.0"
   },
   "dependencies": {
-    "preact": "^8.2.6",
-    "preact-compat": "^3.17.0",
-    "preact-render-to-string": "^4.1.0",
-    "preact-router": "^2.5.7"
+    "preact": "^10.0.0-rc.0",
+    "preact-render-to-string": "^5.0.6",
+    "preact-router": "^3.0.0"
   },
   "jest": {
     "verbose": true,
     "setupFiles": [
+      "<rootDir>/tests/__mocks__/setupTests.js",
       "<rootDir>/tests/__mocks__/browserMocks.js"
     ],
     "testRegex": "(/(__tests__|tests)/.*|(\\.|/)(test|spec))\\.jsx?$",
-    "testPathIgnorePatterns": ["/node_modules/", "<rootDir>/tests/__mocks__/*"],
+    "testPathIgnorePatterns": [
+      "/node_modules/",
+      "<rootDir>/tests/__mocks__/*"
+    ],
     "testURL": "http://localhost:8080",
     "moduleFileExtensions": [
       "js",
@@ -50,13 +55,12 @@
       "node_modules"
     ],
     "moduleNameMapper": {
-      "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/tests/__mocks__/fileMock.js",
+      "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/tests/__mocks__/fileMocks.js",
       "\\.(css|less|scss)$": "identity-obj-proxy",
       "^./style$": "identity-obj-proxy",
-      "^preact$": "<rootDir>/node_modules/preact/dist/preact.min.js",
-      "^react$": "preact-compat",
-      "^react-dom$": "preact-compat",
-      "^create-react-class$": "preact-compat/lib/create-react-class",
+      "^preact$": "<rootDir>/node_modules/preact/dist/preact.js",
+      "^react$": "<rootDir>/node_modules/preact/compat/dist/compat.js",
+      "^react-dom$": "<rootDir>/node_modules/preact/compat/dist/compat.js",
       "^react-addons-css-transition-group$": "preact-css-transition-group"
     }
   }

--- a/template/tests/__mocks__/setupTests.js
+++ b/template/tests/__mocks__/setupTests.js
@@ -1,0 +1,6 @@
+import { configure } from 'enzyme';
+import Adapter from 'enzyme-adapter-preact-pure';
+
+configure({
+	adapter: new Adapter()
+});

--- a/template/tests/header.test.js
+++ b/template/tests/header.test.js
@@ -1,12 +1,13 @@
 import Header from '../src/components/header';
 import { Link } from 'preact-router/match';
-// See: https://github.com/mzgoddard/preact-render-spy
-import { shallow } from 'preact-render-spy';
+// See: https://github.com/preactjs/enzyme-adapter-preact-pure
+import { shallow } from 'enzyme';
+import { h } from 'preact';
 
 describe('Initial Test of the Header', () => {
 	test('Header renders 3 nav items', () => {
 		const context = shallow(<Header />);
 		expect(context.find('h1').text()).toBe('Preact App');
-		expect(context.find(<Link />).length).toBe(3);
+		expect(context.find('Link').length).toBe(3);
 	});
 });


### PR DESCRIPTION
This PR updates default to support Preact X. Feel free to disregard this PR if you are already doing this work yourself.

- Updates all dependencies
- Removes `preact-compat`
- Replaces `preact serve` with `serve build --single`
- Replaces `preact-render-spy` with `enzyme-adapter-preact-pure`
- Fixes `fileMocks` typo in `moduleNameMapper` (from #25)
- Fixes `preact` reference in `moduleNameMapper`
- Fixes `testPathIgnorePatterns` formatting automatically applied to `package.json`

**This PR should not be merged until `preact` and `preact-cli` have come out of release candidate.**