### PR TITLE
Fix broken jest tests

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -23,9 +23,9 @@
     "eslint": "^4.9.0",
     "eslint-config-synacor": "^2.0.2",
     "per-env": "^1.0.2",
-    "jest": "^21.2.1",
+    "jest": "^24.9.0",
     "jest-preset-preact": "^1.0.0",
-    "preact-cli": "^2.1.0",
+    "preact-cli": "3.0.0-rc.5",
     "preact-render-spy": "^1.2.1"
   },
   "dependencies": {

--- a/template/src/components/header/index.js
+++ b/template/src/components/header/index.js
@@ -1,6 +1,6 @@
 import { h } from 'preact';
 import { Link } from 'preact-router/match';
-import style from './style';
+import style from './style.css';
 
 const Header = () => (
 	<header class={style.header}>

--- a/template/tests/header.test.js
+++ b/template/tests/header.test.js
@@ -1,3 +1,4 @@
+import { h } from 'preact';
 import Header from '../src/components/header';
 import { Link } from 'preact-router/match';
 // See: https://github.com/mzgoddard/preact-render-spy


### PR DESCRIPTION
This fixes tests as noted by @andreek but has two ongoing issues:

1) it references preact-cli 3.0.0-rc.5 as we have no better at the moment
2) style.css fix should be done in preact-cli jest configuration instead -
we need to add 'css' to moduleFileExtensions
https://jestjs.io/docs/en/configuration#modulefileextensions-array-string