### PR TITLE
Switch to official preact eslint config

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -14,16 +14,16 @@
     "test": "jest"
   },
   "eslintConfig": {
-    "extends": "eslint-config-synacor"
+    "extends": "preact",
+    "ignorePatterns": [
+      "build/"
+    ]
   },
-  "eslintIgnore": [
-    "build/*"
-  ],
   "devDependencies": {
     "enzyme": "^3.10.0",
     "enzyme-adapter-preact-pure": "^2.0.0",
     "eslint": "^6.0.1",
-    "eslint-config-synacor": "^3.0.4",
+    "eslint-config-preact": "^1.0.0",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^24.9.0",
     "jest-preset-preact": "^1.0.0",
@@ -33,15 +33,15 @@
     "serve": "^11.1.0"
   },
   "dependencies": {
-    "preact": "^10.0.1",
-    "preact-render-to-string": "^5.1.0",
-    "preact-router": "^3.0.0"
+    "preact": "^10.3.2",
+    "preact-render-to-string": "^5.1.4",
+    "preact-router": "^3.2.1"
   },
   "jest": {
     "preset": "jest-preset-preact",
     "setupFiles": [
-			"<rootDir>/tests/__mocks__/browserMocks.js",
-			"<rootDir>/tests/__mocks__/setupTests.js"
-		]
+      "<rootDir>/tests/__mocks__/browserMocks.js",
+      "<rootDir>/tests/__mocks__/setupTests.js"
+    ]
   }
 }

--- a/template/package.json
+++ b/template/package.json
@@ -23,7 +23,7 @@
     "enzyme": "^3.10.0",
     "enzyme-adapter-preact-pure": "^2.0.0",
     "eslint": "^6.0.1",
-    "eslint-config-preact": "^1.0.0",
+    "eslint-config-preact": "^1.1.0",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^24.9.0",
     "jest-preset-preact": "^1.0.0",


### PR DESCRIPTION
This switches the template to use the official (and less-opinionated) [eslint-config-preact](https://github.com/preactjs/eslint-config-preact) preset.