### PR TITLE
Removal of per-env as per #1062

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -4,11 +4,8 @@
   "version": "0.0.0",
   "license": "MIT",
   "scripts": {
-    "start": "preact watch",
-    "start:production": "npm run -s serve",
-    "start:development": "npm run -s dev",
     "build": "preact build",
-    "serve": "preact build && sirv build --cors --single",
+    "serve": "sirv build --cors --single",
     "dev": "preact watch",
     "lint": "eslint src",
     "test": "jest"

--- a/template/package.json
+++ b/template/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "license": "MIT",
   "scripts": {
-    "start": "per-env",
+    "start": "preact watch",
     "start:production": "npm run -s serve",
     "start:development": "npm run -s dev",
     "build": "preact build",
@@ -27,7 +27,6 @@
     "identity-obj-proxy": "^3.0.0",
     "jest": "^24.9.0",
     "jest-preset-preact": "^1.0.0",
-    "per-env": "^1.0.2",
     "preact-cli": "^3.0.0-rc.6",
     "preact-render-spy": "^1.2.1",
     "sirv-cli": "^0.4.5"


### PR DESCRIPTION
Per-env is broken on windows and as such users who follow the preact-cli instructions are unable to start the dev environment. Based on the discussion of #1062 it was advised by @ForsakenHarmony to remove the per-env dependency.