### PR TITLE
Remove lockfiles from .gitignore

### DIFF
--- a/template/.gitignore
+++ b/template/.gitignore
@@ -1,6 +1,3 @@
 node_modules
 /build
 /*.log
-*.lock
-
-package-lock.json


### PR DESCRIPTION
It is best practice to keep the npm/yarn lockfile for reproducible builds.

https://classic.yarnpkg.com/blog/2016/11/24/lockfiles-for-all/