### PR TITLE
refactor(deps): Removing render-spy and identity-obj

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ Development server runs on port `8080`. If the default port is already in use on
 
 - `npm run lint`: Pass JavaScript files using ESLint
 
-- `npm run test`: Run Jest and [`preact-render-spy`](https://github.com/mzgoddard/preact-render-spy) for your tests
+- `npm run test`: Run Jest and Enzyme with [`enzyme-adapter-preact-pure`](https://github.com/preactjs/enzyme-adapter-preact-pure) for your tests
 
 ### How to Test
 
-The `default` template provides a basic test setup with Jest and [`preact-render-spy`](https://github.com/mzgoddard/preact-render-spy). You are free to change preact-render-spy with any other assertion library. The advantage of it is that it supports a similiar terminology and feature set as the Enzyme library for testing React applications.
+The `default` template provides a basic test setup with Jest, Enzyme, and [`enzyme-adapter-preact-pure`](https://github.com/preactjs/enzyme-adapter-preact-pure). You are free to change Enzyme with any other testing library (eg. [Preact Testing Library](https://testing-library.com/docs/preact-testing-library/intro)).
 
 You can run all additional Jest CLI commands with the `npm run test` command as described in the [Jest docs](https://facebook.github.io/jest/docs/en/cli.html#using-with-npm-scripts). For example, running jest in watch mode would be :
 

--- a/template/README.md
+++ b/template/README.md
@@ -15,7 +15,7 @@ npm run build
 # test the production build locally
 npm run serve
 
-# run tests with jest and preact-render-spy 
+# run tests with jest and enzyme
 npm run test
 ```
 

--- a/template/package.json
+++ b/template/package.json
@@ -21,11 +21,9 @@
     "enzyme-adapter-preact-pure": "^2.0.0",
     "eslint": "^6.0.1",
     "eslint-config-preact": "^1.1.0",
-    "identity-obj-proxy": "^3.0.0",
     "jest": "^24.9.0",
     "jest-preset-preact": "^1.0.0",
     "preact-cli": "^3.0.0",
-    "preact-render-spy": "^1.2.1",
     "sirv-cli": "1.0.3"
   },
   "dependencies": {


### PR DESCRIPTION
As the title states, this PR removes `preact-render-spy` and `identity-obj-proxy` from the template and its documentation. Neither have been in use since #26 but were never removed.

The documentation updates are a result of copy/paste from the Typescript template. 