### PR TITLE
refactor: Switch to hooks

### DIFF
--- a/template/src/components/app.js
+++ b/template/src/components/app.js
@@ -1,32 +1,21 @@
-import { h, Component } from 'preact';
+import { h } from 'preact';
 import { Router } from 'preact-router';
 
 import Header from './header';
 
-// Code-splitting is automated for routes
+// Code-splitting is automated for `routes` directory
 import Home from '../routes/home';
 import Profile from '../routes/profile';
 
-export default class App extends Component {
-	
-	/** Gets fired when the route changes.
-	 *	@param {Object} event		"change" event from [preact-router](http://git.io/preact-router)
-	 *	@param {string} event.url	The newly routed URL
-	 */
-	handleRoute = e => {
-		this.currentUrl = e.url;
-	};
+const App = () => (
+	<div id="app">
+		<Header />
+		<Router>
+			<Home path="/" />
+			<Profile path="/profile/" user="me" />
+			<Profile path="/profile/:user" />
+		</Router>
+	</div>
+)
 
-	render() {
-		return (
-			<div id="app">
-				<Header />
-				<Router onChange={this.handleRoute}>
-					<Home path="/" />
-					<Profile path="/profile/" user="me" />
-					<Profile path="/profile/:user" />
-				</Router>
-			</div>
-		);
-	}
-}
+export default App;

--- a/template/src/routes/home/index.js
+++ b/template/src/routes/home/index.js
@@ -1,5 +1,5 @@
 import { h } from 'preact';
-import style from './style';
+import style from './style.css';
 
 const Home = () => (
 	<div class={style.home}>

--- a/template/src/routes/profile/index.js
+++ b/template/src/routes/profile/index.js
@@ -1,47 +1,30 @@
-import { h, Component } from 'preact';
-import style from './style';
+import { h } from 'preact';
+import {useEffect, useState} from "preact/hooks";
+import style from './style.css';
 
-export default class Profile extends Component {
-	state = {
-		time: Date.now(),
-		count: 10
-	};
+// Note: `user` comes from the URL, courtesy of our router
+const Profile = ({ user }) => {
+	const [time, setTime] = useState(Date.now());
+	const [count, setCount] = useState(10);
 
-	// update the current time
-	updateTime = () => {
-		this.setState({ time: Date.now() });
-	};
+	useEffect(() => {
+		setInterval(() => setTime(Date.now()), 1000);
+	}, []);
 
-	increment = () => {
-		this.setState({ count: this.state.count+1 });
-	};
+	return (
+		<div class={style.profile}>
+			<h1>Profile: {user}</h1>
+			<p>This is the user profile for a user named { user }.</p>
 
-	// gets called when this route is navigated to
-	componentDidMount() {
-		// start a timer for the clock:
-		this.timer = setInterval(this.updateTime, 1000);
-	}
+			<div>Current time: {new Date(time).toLocaleString()}</div>
 
-	// gets called just before navigating away from the route
-	componentWillUnmount() {
-		clearInterval(this.timer);
-	}
-
-	// Note: `user` comes from the URL, courtesy of our router
-	render({ user }, { time, count }) {
-		return (
-			<div class={style.profile}>
-				<h1>Profile: {user}</h1>
-				<p>This is the user profile for a user named { user }.</p>
-
-				<div>Current time: {new Date(time).toLocaleString()}</div>
-
-				<p>
-					<button onClick={this.increment}>Click Me</button>
-					{' '}
-					Clicked {count} times.
-				</p>
-			</div>
-		);
-	}
+			<p>
+				<button onClick={() => setCount((count) => ++count)}>Click Me</button>
+				{' '}
+				Clicked {count} times.
+			</p>
+		</div>
+	);
 }
+
+export default Profile;

--- a/template/src/routes/profile/index.js
+++ b/template/src/routes/profile/index.js
@@ -8,7 +8,8 @@ const Profile = ({ user }) => {
 	const [count, setCount] = useState(10);
 
 	useEffect(() => {
-		setInterval(() => setTime(Date.now()), 1000);
+		let timer = setInterval(() => setTime(Date.now()), 1000);
+		return () => clearInterval(timer);
 	}, []);
 
 	return (
@@ -19,7 +20,7 @@ const Profile = ({ user }) => {
 			<div>Current time: {new Date(time).toLocaleString()}</div>
 
 			<p>
-				<button onClick={() => setCount((count) => ++count)}>Click Me</button>
+				<button onClick={() => setCount((count) => count + 1)}>Click Me</button>
 				{' '}
 				Clicked {count} times.
 			</p>


### PR DESCRIPTION
## Description

Converts the existing class components into functional components with hooks.

## Reason for Change

Most people in the Preact/React communities these days will be writing functional components with hooks. As such, this template should probably use them. 

If this is a user's first experience with Preact, I'd argue using newer syntax is better. However, maybe one of each should be kept, to show that Preact supports both syntaxes? Not sure myself, depends on what maintainers want. 

### Changelog
* [x]  Convert existing class components (`App` and `Profile`) to use hooks
* [x]  Updated an import (`import style from './style';` -> `import style from './style.css';`) purely for consistency 
