### PR TITLE
fix: usage Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@
 ## Usage
 
 ``` bash
-$ npm install -g preact-cli
-$ preact create default my-project
+$ npx preact-cli create default my-project
 $ cd my-project
 $ npm install
 $ npm run dev


### PR DESCRIPTION
## Description

Corrects usage information to use NPX rather than install the Preact CLI globally

## Reason for Change

The CLI's documentation had an update and now [the recommended way to use it is via NPX](https://github.com/preactjs/preact-cli#usage). This template should say the same.