### PR TITLE
deps: bump some dependencies

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -17,19 +17,19 @@
     ]
   },
   "devDependencies": {
-    "enzyme": "^3.10.0",
-    "enzyme-adapter-preact-pure": "^2.0.0",
-    "eslint": "^6.0.1",
-    "eslint-config-preact": "^1.1.0",
-    "jest": "^24.9.0",
-    "jest-preset-preact": "^1.0.0",
-    "preact-cli": "^3.0.0",
-    "sirv-cli": "1.0.3"
+    "enzyme": "^3.11.0",
+    "enzyme-adapter-preact-pure": "^4.0.1",
+    "eslint": "^8.21.0",
+    "eslint-config-preact": "^1.3.0",
+    "jest": "^28.1.3",
+    "jest-preset-preact": "^4.0.5",
+    "preact-cli": "^3.4.1",
+    "sirv-cli": "2.0.2"
   },
   "dependencies": {
-    "preact": "^10.3.2",
-    "preact-render-to-string": "^5.1.4",
-    "preact-router": "^3.2.1"
+    "preact": "^10.10.0",
+    "preact-render-to-string": "^5.2.1",
+    "preact-router": "^4.1.0"
   },
   "jest": {
     "preset": "jest-preset-preact",


### PR DESCRIPTION
## WHAT

While working with this template i noticed there is some bump that could be made on its dependencies, that's why i made this PR !

More details:
preact                      ^10.3.2  →  ^10.10.0
preact-render-to-string      ^5.1.4  →    ^5.2.1
preact-router                ^3.2.1  →    ^4.1.0
enzyme                      ^3.10.0  →   ^3.11.0
enzyme-adapter-preact-pure   ^2.0.0  →    ^4.0.1
eslint                       ^6.0.1  →   ^8.21.0
eslint-config-preact         ^1.1.0  →    ^1.3.0
jest                        ^24.9.0  →   ^28.1.3
jest-preset-preact           ^1.0.0  →    ^4.0.5
preact-cli                   ^3.0.0  →    ^3.4.1
sirv-cli                      1.0.3  →     2.0.2
