### PR TITLE
refactor: Update content

### DIFF
--- a/template/src/assets/preact-logo-inverse.svg
+++ b/template/src/assets/preact-logo-inverse.svg
@@ -1,0 +1,14 @@
+<svg
+    width="32px"
+    height="32px"
+    viewBox="-256 -256 512 512"
+    version="1.1"
+    xmlns="http://www.w3.org/2000/svg"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    xml:space="preserve"
+    >
+    <path d="M0,-256 221.7025033688164,-128 221.7025033688164,128 0,256 -221.7025033688164,128 -221.7025033688164,-128z" fill="white"/>
+    <ellipse cx="0" cy="0" stroke-width="16px" rx="75px" ry="196px" fill="none" stroke="#673ab8" transform="rotate(52.5)"/>
+    <ellipse cx="0" cy="0" stroke-width="16px" rx="75px" ry="196px" fill="none" stroke="#673ab8" transform="rotate(-52.5)"/>
+    <circle cx="0" cy="0" r="34" fill="#673ab8"/>
+</svg>

--- a/template/src/assets/preact-logo.svg
+++ b/template/src/assets/preact-logo.svg
@@ -1,0 +1,14 @@
+<svg
+    width="32px"
+    height="32px"
+    viewBox="-256 -256 512 512"
+    version="1.1"
+    xmlns="http://www.w3.org/2000/svg"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    xml:space="preserve"
+    >
+    <path d="M0,-256 221.7025033688164,-128 221.7025033688164,128 0,256 -221.7025033688164,128 -221.7025033688164,-128z" fill="#673ab8"/>
+    <ellipse cx="0" cy="0" stroke-width="16px" rx="75px" ry="196px" fill="none" stroke="white" transform="rotate(52.5)"/>
+    <ellipse cx="0" cy="0" stroke-width="16px" rx="75px" ry="196px" fill="none" stroke="white" transform="rotate(-52.5)"/>
+    <circle cx="0" cy="0" r="34" fill="white"/>
+</svg>

--- a/template/src/components/app.js
+++ b/template/src/components/app.js
@@ -10,11 +10,13 @@ import Profile from '../routes/profile';
 const App = () => (
 	<div id="app">
 		<Header />
-		<Router>
-			<Home path="/" />
-			<Profile path="/profile/" user="me" />
-			<Profile path="/profile/:user" />
-		</Router>
+		<main>
+			<Router>
+				<Home path="/" />
+				<Profile path="/profile/" user="me" />
+				<Profile path="/profile/:user" />
+			</Router>
+		</main>
 	</div>
 );
 

--- a/template/src/components/header/index.js
+++ b/template/src/components/header/index.js
@@ -4,7 +4,10 @@ import style from './style.css';
 
 const Header = () => (
 	<header class={style.header}>
-		<h1>Preact App</h1>
+		<a href="/" class={style.logo}>
+			<img src="../../assets/preact-logo-inverse.svg" alt="Preact Logo" />
+			<h1>Preact CLI</h1>
+		</a>
 		<nav>
 			<Link activeClassName={style.active} href="/">
 				Home

--- a/template/src/components/header/style.css
+++ b/template/src/components/header/style.css
@@ -2,45 +2,48 @@
 	position: fixed;
 	left: 0;
 	top: 0;
+
+	display: flex;
+	justify-content: space-between;
+
 	width: 100%;
-	height: 56px;
-	padding: 0;
-	background: #673ab7;
+	height: 3.5rem;
+
+	background: #673ab8;
 	box-shadow: 0 0 5px rgba(0, 0, 0, 0.5);
 	z-index: 50;
 }
 
-.header h1 {
-	float: left;
-	margin: 0;
-	padding: 0 15px;
-	font-size: 24px;
-	line-height: 56px;
-	font-weight: 400;
-	color: #fff;
-}
-
-.header nav {
-	float: right;
-	font-size: 100%;
-}
-
-.header nav a {
+.header a {
 	display: inline-block;
-	height: 56px;
-	line-height: 56px;
-	padding: 0 15px;
-	min-width: 50px;
-	text-align: center;
-	background: rgba(255, 255, 255, 0);
-	text-decoration: none;
+	padding: 0 1rem;
 	color: #fff;
-	will-change: background-color;
+	text-decoration: none;
+	line-height: 3.5rem;
 }
 
-.header nav a:hover,
-.header nav a:active {
+.header a:hover,
+.header a:active {
 	background: rgba(0, 0, 0, 0.2);
+}
+
+.header a.logo {
+	display: flex;
+	align-items: center;
+	padding: 0.5rem 1rem;
+}
+
+.logo h1 {
+	padding: 0 0.5rem;
+	font-size: 1.5rem;
+	line-height: 2rem;
+	font-weight: 400;
+}
+
+@media (max-width: 639px) {
+	.logo h1 {
+		display: none;
+	}
 }
 
 .header nav a.active {

--- a/template/src/routes/home/index.js
+++ b/template/src/routes/home/index.js
@@ -1,11 +1,41 @@
 import { h } from 'preact';
 import style from './style.css';
 
-const Home = () => (
-	<div class={style.home}>
-		<h1>Home</h1>
-		<p>This is the Home component.</p>
-	</div>
-);
+const Home = () => {
+	return (
+		<div class={style.home}>
+			<a href="https://preactjs.com">
+				<img src="../../assets/preact-logo.svg" alt="Preact Logo" />
+			</a>
+			<h1>Get Started Building PWAs with Preact-CLI</h1>
+			<section>
+				<Resource
+					title="Learn Preact"
+					description="If you're new to Preact, try the interactive tutorial to learn important concepts"
+					link="https://preactjs.com/tutorial/"
+				/>
+				<Resource
+					title="Differences to React"
+					description="If you're coming from React, check out our docs for where Preact differs"
+					link="https://preactjs.com/guide/v10/differences-to-react"
+				/>
+				<Resource
+					title="Learn Preact-CLI"
+					description="To learn more about Preact-CLI, read through the ReadMe & Wiki"
+					link="https://github.com/preactjs/preact-cli#preact-cli--"
+				/>
+			</section>
+		</div>
+	);
+};
+
+const Resource = props => {
+	return (
+		<a href={props.link} class={style.resource}>
+			<h2>{props.title}</h2>
+			<p>{props.description}</p>
+		</a>
+	);
+};
 
 export default Home;

--- a/template/src/routes/home/style.css
+++ b/template/src/routes/home/style.css
@@ -1,5 +1,53 @@
 .home {
-	padding: 56px 20px;
-	min-height: 100%;
-	width: 100%;
+	text-align: center;
+}
+
+.home img {
+	height: 10rem;
+	padding: 1.5rem;
+}
+
+.home img:hover {
+	filter: drop-shadow(0 0 3rem #673ab888);
+}
+
+.home section {
+	margin-top: 10rem;
+	display: grid;
+	grid-template-columns: 1fr 1fr 1fr;
+	column-gap: 1.5rem;
+}
+
+@media (max-width: 639px) {
+	.home section {
+		margin-top: 5rem;
+		grid-template-columns: 1fr;
+		row-gap: 1rem;
+	}
+}
+
+.resource {
+	padding: 0.75rem 1.5rem;
+	border-radius: 0.5rem;
+	text-align: left;
+	text-decoration: none;
+	color: #000;
+	background-color: #f1f1f1;
+	border: 1px solid transparent;
+}
+
+.resource:hover {
+	border: 1px solid #000;
+	box-shadow: 0 25px 50px -12px #673ab888;
+}
+
+@media (prefers-color-scheme: dark) {
+	.resource {
+		color: #fff;
+		background-color: #181818;
+	}
+	.resource:hover {
+		border: 1px solid #bbb;
+		box-shadow: 0 25px 50px -12px #673ab888;
+	}
 }

--- a/template/src/routes/profile/index.js
+++ b/template/src/routes/profile/index.js
@@ -1,6 +1,5 @@
 import { h } from 'preact';
 import { useEffect, useState } from 'preact/hooks';
-import style from './style.css';
 
 // Note: `user` comes from the URL, courtesy of our router
 const Profile = ({ user }) => {
@@ -13,7 +12,7 @@ const Profile = ({ user }) => {
 	}, []);
 
 	return (
-		<div class={style.profile}>
+		<div>
 			<h1>Profile: {user}</h1>
 			<p>This is the user profile for a user named {user}.</p>
 

--- a/template/src/routes/profile/style.css
+++ b/template/src/routes/profile/style.css
@@ -1,5 +1,0 @@
-.profile {
-	padding: 56px 20px;
-	min-height: 100%;
-	width: 100%;
-}

--- a/template/src/style/index.css
+++ b/template/src/style/index.css
@@ -1,21 +1,39 @@
-html,
-body {
-	height: 100%;
-	width: 100%;
-	padding: 0;
-	margin: 0;
-	background: #fafafa;
+:root {
 	font-family: 'Helvetica Neue', arial, sans-serif;
 	font-weight: 400;
-	color: #444;
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
+
+	color-scheme: light dark;
+	color: #444;
+	background: #fafafa;
 }
 
-* {
-	box-sizing: border-box;
+@media (prefers-color-scheme: dark) {
+	:root {
+		color: #fff;
+		background: #1c1c1c;
+	}
 }
 
-#app {
-	height: 100%;
+body {
+	margin: 0;
+	padding: 0;
+	min-height: 100vh;
+}
+
+#app > main {
+	display: flex;
+	padding-top: 3.5rem;
+	margin: 0 auto;
+	min-height: calc(100vh - 3.5rem);
+	max-width: 1280px;
+	align-items: center;
+	justify-content: center;
+}
+
+@media (max-width: 639px) {
+	#app > main {
+		margin: 0 2rem;
+	}
 }


### PR DESCRIPTION
Our templates were in need of a bit of a face lift, as, compared to other tools, they look rather empty and are missing some "next steps" resources for where to go after project initialization.

Before             |  After (Light)  | After (Dark)
:-------------------------:|:-------------------------:|:-------------------------:
![Before this PR](https://user-images.githubusercontent.com/33403762/209762143-514840ed-3251-4348-b649-104f0a9778ec.png) | ![After this PR](https://user-images.githubusercontent.com/33403762/209762209-4211677d-824d-4a0c-8724-60df22c4c855.png) | ![After this PR (Dark)](https://user-images.githubusercontent.com/33403762/209762224-dffb8aef-0a65-4486-9a21-bccb5a8bafee.png)


